### PR TITLE
Connect method name change

### DIFF
--- a/lib/auto-uri.js
+++ b/lib/auto-uri.js
@@ -29,7 +29,7 @@ function AutoUri(hostname, opts) {
 
     self.express = express.createServer(
         express.logger(),
-        express.bodyDecoder()
+        express.bodyParser()
     );
     self.express.listen(self.port);
 


### PR DESCRIPTION
In Connect 1.0, the bodyDecoder method has been renamed to bodyParser. Thanks for the great work on the node-twilio module!
