### PR TITLE
Bug: starting server for consumer.

### DIFF
--- a/lib/auto-uri.js
+++ b/lib/auto-uri.js
@@ -26,11 +26,17 @@ function AutoUri(hostname, opts) {
         'DELETE': {},
         'PUT': {}
     };
-    self.express = opts.express || express.createServer(
-        express.logger(),
-        express.bodyParser()
-    );
-    self.express.listen(self.port);
+  
+    if(opts.express) {
+      self.express = opts.express;
+    }
+    else {
+      self.express = express.createServer(
+          express.logger(),
+          express.bodyParser()
+      );
+      self.express.listen(self.port);
+    }
 
     self.baseUri = 'http://' + self.hostname + ':' + self.port + '/' + self.basePath + '/';
     self.expressPath = '/' + self.basePath + '/:index';


### PR DESCRIPTION
You don't want to start the server for the consumer-- they may have already started it when they add your routes, which causes a fatal error.

If the consumer provides a server, they must be responsible for setting it up.
