### PR TITLE
Client externalPort option for Heroku compatibility

### DIFF
--- a/lib/auto-uri.js
+++ b/lib/auto-uri.js
@@ -18,7 +18,8 @@ function AutoUri(hostname, opts) {
     
     opts = opts || {};
     self.hostname = hostname;
-    self.port = opts.port || 31337;
+    self.port = opts.port || process.env.PORT || 31337;
+		self.externalPort = opts.externalPort;
     self.basePath = opts.basePath || 'autoprovision';
     self.provisionedPaths = {
         'GET': {},
@@ -32,7 +33,7 @@ function AutoUri(hostname, opts) {
     );
     self.express.listen(self.port);
 
-    self.baseUri = 'http://' + self.hostname + ':' + self.port + '/' + self.basePath + '/';
+    self.baseUri = 'http://' + self.hostname + ( self.externalPort ? ':' + self.externalPort : '') + '/' + self.basePath + '/';
     self.expressPath = '/' + self.basePath + '/:index';
     self.index = 0;
 


### PR DESCRIPTION
On Heorku node.js apps run on port 80 but listen on process.env.PORT, this patch makes that possible.
