### PR TITLE
Added support for sandbox resource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 test/config.js
 examples/*/config.js
+node_modules/

--- a/examples/sandbox/config.js.sample
+++ b/examples/sandbox/config.js.sample
@@ -1,0 +1,7 @@
+module.exports.Credentials = {
+    sid: 'ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+    authToken: 'dcXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+    incoming: '+18888238895',
+    outgoing: '+18674451795',
+    hostname: 'example.com'
+};

--- a/examples/sandbox/dial-list.js
+++ b/examples/sandbox/dial-list.js
@@ -1,0 +1,26 @@
+var TwilioClient = require('../../lib').Client,
+    Twiml = require('../../lib/').Twiml,
+    creds = require('./config').Credentials,
+    client = new TwilioClient(creds.sid, creds.authToken, creds.hostname),
+    numbers = ['+18674451795', '+19058926737', '+18888238895'],
+    message = 'Hey there! You are loved. We are on the side of damage, and you are loved.',
+    totalToCall = numbers.length,
+    totalCalled = 0;
+
+var sandbox = client.getSandbox();
+sandbox.setup(function() {
+    // We'll dial each of the numbers in 'numbers' and play them the message
+    for(var i = 0; i < numbers.length; i++) {
+        sandbox.makeCall(numbers[i], null, function(call) {
+            call.on('answered', function(reqParams, res) {
+                res.append(new Twiml.Say(message)).append(new Twiml.Hangup());
+                res.send();
+                totalCalled += 1;
+                if(totalToCall == totalCalled) {
+                    // We're done!
+                    process.exit(0);
+                }
+            });
+        });
+    }
+});

--- a/examples/sandbox/sms-list.js
+++ b/examples/sandbox/sms-list.js
@@ -1,0 +1,26 @@
+var TwilioClient = require('../../lib').Client,
+    Twiml = require('../../lib/').Twiml,
+    creds = require('./config').Credentials,
+    client = new TwilioClient(creds.sid, creds.authToken, creds.hostname),
+    // Our numbers list. Add more numbers here and they'll get the message
+    numbers = ['+18674451795'],
+    message = 'WE DAMAGE WE',
+    numToSend = numbers.length,
+    numSent = 0;
+
+var sandbox = client.getSandbox();
+sandbox.setup(function() {
+    for(var i = 0; i < numbers.length; i++) {
+        sandbox.sendSms(numbers[i], message, null, function(sms) {
+            sms.on('processed', function(reqParams, response) {
+                console.log('Message processed, request params follow');
+                console.log(reqParams);
+                numSent += 1;
+                if(numSent == numToSend) {
+                    // We're done!
+                    process.exit(0);
+                }
+            });
+        });
+    }
+});

--- a/lib/rest-client.js
+++ b/lib/rest-client.js
@@ -479,3 +479,20 @@ RestClient.prototype.deleteNotification = function(sid, suc, err) {
 
     this.apiCall('DELETE', '/Notifications/' + sid, null, suc, err);
 };
+
+//-----------------------------------------------------------------------------
+//--------------------- Sandbox
+//-----------------------------------------------------------------------------
+
+/**
+ * getSandboxInfo: Get the sandbox resource
+ *
+ * See: http://www.twilio.com/docs/api/2010-04-01/rest/sandbox
+ */
+RestClient.prototype.getSandboxInfo = function(suc, err) {
+    this.apiCall('GET', '/Sandbox', null, suc, err);
+};
+
+RestClient.prototype.updateSandboxInfo = function(params, suc, err) {
+    this.apiCall('POST', '/Sandbox', {params: params}, suc, err);
+};

--- a/lib/twilio.js
+++ b/lib/twilio.js
@@ -170,6 +170,92 @@ PhoneNumber.prototype.setup = function(fn) {
     }
 };
 
+/**
+ * getSandbox: Return a new Sandbox object
+ */
+Client.prototype.getSandbox = function() {
+    return new Sandbox(this);
+};
+
+/**
+ * Sandbox class: Represents the sandbox
+ */
+function Sandbox(client) {
+    var self = this;
+
+    if(!client) {
+        throw new Error('client argument required');
+    }
+
+    EventEmitter.call(this);
+
+    this.client = client;
+    this.attrs = {};
+
+    function handleEvent(event) {
+        return function(req, res) {
+            var reqParams = req.body;
+            self.emit(event, reqParams, (new Twiml.Response(res)));
+        };
+    }
+
+    this.on('newListener', function(listener) {
+        var update = {};
+
+        if(listener == 'incomingSms') {
+            update.SmsUrl = autoUri.addCallback('POST', handleEvent('incomingSms'));
+        } else if(listener == 'incomingCall') {
+            update.VoiceUrl = autoUri.addCallback('POST', handleEvent('incomingCall'));
+        } else if(listener == 'callStatus') {
+            update.StatusCallback = autoUri.addCallback('POST', handleEvent('callStatus'));
+        }
+
+        self.client.updateSandboxInfo(update);
+    });
+}
+
+util.inherits(Sandbox, EventEmitter);
+
+/**
+ * getSandboxDetails: Retrieve the details for the sandbox
+ *
+ * @param {Function} fn: Callback for completion
+ */
+Sandbox.prototype.getSandboxDetails = function(fn) {
+    var self = this;
+
+    function populate(sandboxDetails) {
+        self.attrs.phoneNumber = sandboxDetails.phone_number;
+        self.attrs.voiceUrl = sandboxDetails.voice_url;
+        self.attrs.voiceMethod = sandboxDetails.voice_method;
+        self.attrs.statusCallback = sandboxDetails.status_callback;
+        self.attrs.statusCallbackMethod = sandboxDetails.status_callback_method;
+        self.attrs.smsUrl = sandboxDetails.sms_url;
+        self.attrs.smsMethod = sandboxDetails.sms_method;
+
+        if(typeof fn == 'function') fn();
+    }
+
+    self.client.getSandboxInfo(function(resp) {
+        populate(resp);
+    });
+};
+
+/**
+ * setup: Configure the sandbox to start emitting events
+ *
+ * @param {Function} fn: Called on completion
+ */
+Sandbox.prototype.setup = function(fn) {
+    var self = this;
+
+    if(!self.attrs.phoneNumber) {
+        self.getSandboxDetails(fn);
+    } else {
+        if(typeof fn == 'function') fn();
+    }
+};
+
 function OutgoingCall(from, to, opts, restClient) {
     // An outgoing call with emit: callAnswered, callEnded
     this.rest = restClient;
@@ -207,6 +293,11 @@ PhoneNumber.prototype.makeCall = function(to, opts, fn) {
     call.setup(fn);
 };
 
+Sandbox.prototype.makeCall = function(to, opts, fn) {
+    var call = new OutgoingCall(this.attrs.phoneNumber, to, opts, this.client);
+    call.setup(fn);
+};
+
 function OutgoingSms(from, to, body, opts, restClient) {
     this.rest = restClient;
     this.from = from;
@@ -234,6 +325,11 @@ OutgoingSms.prototype.setup = function(fn) {
 };
 
 PhoneNumber.prototype.sendSms = function(to, body, opts, fn) {
+    var sms = new OutgoingSms(this.attrs.phoneNumber, to, body, opts, this.client);
+    sms.setup(fn);
+};
+
+Sandbox.prototype.sendSms = function(to, body, opts, fn) {
     var sms = new OutgoingSms(this.attrs.phoneNumber, to, body, opts, this.client);
     sms.setup(fn);
 };


### PR DESCRIPTION
This commit allows a trial user to use the sandbox phone number in the same manner one would use the PhoneNumber object:

```
var sandbox = client.getSandbox();
console.log('Phone number is: ' + sandbox.attrs.phoneNumber);
sandbox.setup(function() {
  sandbox.sendSms(...);
  sandbox.makeCall(...);
});
```

I've replicated the dial-list and sms-list examples in a sandbox example.
